### PR TITLE
Switch default Ollama model to Qwen2.5-Coder 7B for art concept generation

### DIFF
--- a/OLLAMA_INTEGRATION.md
+++ b/OLLAMA_INTEGRATION.md
@@ -37,7 +37,7 @@ autonomousART now supports **Ollama-based concept generation** similar to the au
 
 Features:
 - Connects to local Ollama instance at `http://localhost:11434` (configurable via `OLLAMA_URL` env var)
-- Uses configurable model (default: `mistral`, configurable via `OLLAMA_MODEL` env var)
+- Uses configurable model (default: `qwen2.5-coder:7b`, configurable via `OLLAMA_MODEL` env var)
 - 10-minute timeout for generation (suitable for slower inference)
 - Structured prompt generation with art-specific parameters
 - Intelligent response parsing to extract:
@@ -47,6 +47,17 @@ Features:
   - Color palette (hex codes)
   - Emotional tone
   - Interaction type
+
+### Model Selection Research (for code-driven mathematical art)
+
+Default model is now **`qwen2.5-coder:7b`** instead of tiny/general small models because:
+
+- It is open-weight and available in Ollama.
+- It is tuned for code synthesis, which helps produce structured algorithmic prompts that map better to Canvas/JS generation.
+- It is generally stronger at math + reasoning heavy tasks than tiny baseline models, improving consistency for fractals, particle systems, and geometry-driven concepts.
+- It still runs locally on commodity hardware compared with larger reasoning models.
+
+If your machine can support bigger models, you can still override with `OLLAMA_MODEL`.
 
 ### Generation Process
 
@@ -67,7 +78,7 @@ Features:
 ```bash
 cd autonomousART
 export OLLAMA_URL="http://localhost:11434"
-export OLLAMA_MODEL="mistral"
+export OLLAMA_MODEL="qwen2.5-coder:7b"
 node scripts/ollama-concept-generator.js
 ```
 
@@ -81,7 +92,7 @@ Update `concept-selector.js` to call Ollama first, then fallback to Gemini API o
 - name: Generate art with Ollama
   env:
     OLLAMA_URL: http://localhost:11434
-    OLLAMA_MODEL: mistral
+    OLLAMA_MODEL: qwen2.5-coder:7b
   run: |
     node scripts/ollama-concept-generator.js
     node scripts/art-generator.js
@@ -115,7 +126,7 @@ Update `concept-selector.js` to call Ollama first, then fallback to Gemini API o
 ## Environment Variables
 
 - `OLLAMA_URL`: Ollama server URL (default: `http://localhost:11434`)
-- `OLLAMA_MODEL`: Model to use (default: `mistral`)
+- `OLLAMA_MODEL`: Model to use (default: `qwen2.5-coder:7b`)
 
 ## Comparison: autonomousBLOG vs autonomousART
 
@@ -123,7 +134,7 @@ Update `concept-selector.js` to call Ollama first, then fallback to Gemini API o
 |--------|---|---|
 | **Inference Type** | Text generation (articles) | Concept generation |
 | **Output** | Markdown files | JSON concept + HTML/Canvas art |
-| **Model** | Mistral | Mistral (same) |
+| **Model** | Mistral | Qwen2.5-Coder 7B |
 | **Timeout** | 10 minutes | 10 minutes |
 | **Tokens** | 1024 | 1500 |
 | **Temperature** | 0.7 | 0.8 (more creative) |
@@ -144,7 +155,7 @@ Update `concept-selector.js` to call Ollama first, then fallback to Gemini API o
 ollama serve
 
 # Pull model (if not already present)
-ollama pull mistral
+ollama pull qwen2.5-coder:7b
 
 # Generate a concept
 cd autonomousART

--- a/scripts/concept-selector.js
+++ b/scripts/concept-selector.js
@@ -16,7 +16,7 @@ const HISTORY_FILE = path.join(__dirname, '..', 'concept-history.json');
 const PROMPT_FILE = path.join(__dirname, '..', 'prompts', 'art-generation.txt');
 
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'mistral';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen2.5-coder:7b';
 
 const ART_TECHNIQUES = [
   'Fractal Mathematics',

--- a/scripts/ollama-concept-generator.js
+++ b/scripts/ollama-concept-generator.js
@@ -11,7 +11,7 @@ const path = require('path');
 const OllamaInference = require('./ollama-inference');
 
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'tinyllama';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen2.5-coder:7b';
 const CONCEPT_FILE = path.join(__dirname, '..', 'selected-concept.json');
 const PROMPT_FILE = path.join(__dirname, '..', 'prompts', 'art-generation.txt');
 const HISTORY_FILE = path.join(__dirname, '..', 'concept-history.json');

--- a/scripts/ollama-inference.js
+++ b/scripts/ollama-inference.js
@@ -9,7 +9,7 @@
 const fetch = require('node-fetch');
 
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://localhost:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'mistral';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen2.5-coder:7b';
 
 class OllamaInference {
   constructor(url = OLLAMA_URL, model = OLLAMA_MODEL) {


### PR DESCRIPTION
### Motivation
- The previous small defaults (`tinyllama` / `mistral`) produced weak or unreliable results for structured, math- and code-heavy concept generation.  
- A model tuned for code synthesis and reasoning will produce more consistent, structured prompts that map better to Canvas/JS generative-art code.  
- `qwen2.5-coder:7b` is an open-weight model available for local Ollama use and is a good balance of capability and local runtime cost.

### Description
- Changed the default `OLLAMA_MODEL` to `qwen2.5-coder:7b` in the runtime scripts: `scripts/ollama-concept-generator.js`, `scripts/ollama-inference.js`, and `scripts/concept-selector.js`.  
- Updated `OLLAMA_INTEGRATION.md` examples and setup commands (env examples, workflow snippet, `ollama pull` example) and the comparison table to reflect the new default model.  
- Added a short "Model Selection Research" note in `OLLAMA_INTEGRATION.md` explaining why `qwen2.5-coder:7b` is preferred for code/math-driven art concepts.  
- Left model selection configurable via the `OLLAMA_MODEL` environment variable so users can override if they prefer other models.

### Testing
- Ran syntax checks on updated scripts with `node --check scripts/ollama-concept-generator.js`, `node --check scripts/ollama-inference.js`, and `node --check scripts/concept-selector.js`, and they completed without errors.  
- No other automated test suite was present or executed for these changes.  
- Files were committed after verification (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c75254248329a438b31b39ba9d76)